### PR TITLE
[✨Feat] supabase 테이블을 가져오는 공용 함수 생성

### DIFF
--- a/src/app/notice/[id]/page.tsx
+++ b/src/app/notice/[id]/page.tsx
@@ -1,4 +1,4 @@
-import { getNoticeById } from '@/lib/noticeService';
+import { getNoticeById } from '../_lib/noticeService';
 import { NoticeContent } from '@/lib/types/notice';
 
 export const revalidate = 60; // 60초마다 재검증

--- a/src/app/notice/[id]/page.tsx
+++ b/src/app/notice/[id]/page.tsx
@@ -1,10 +1,10 @@
 import { getNoticeById } from '../_lib/noticeService';
-import { NoticeContent } from '@/lib/types/notice';
+import { NoticeTable } from '@/lib/types/database';
 
 export const revalidate = 60; // 60초마다 재검증
 
 export default async function NoticeDetailPage({ params }: { params: { id: string } }) {
-  const notice: NoticeContent | null = await getNoticeById(parseInt(params.id));
+  const notice: NoticeTable | null = await getNoticeById(parseInt(params.id));
 
   if (!notice) {
     return <div>공지사항을 찾을 수 없습니다.</div>;
@@ -13,9 +13,7 @@ export default async function NoticeDetailPage({ params }: { params: { id: strin
   return (
     <div className="container mx-auto p-4">
       <h1 className="mb-4 text-3xl font-bold">{notice.title}</h1>
-      <div className="mb-4 text-sm text-gray-500">
-        작성자: {notice.author} | 작성일: {new Date(notice.created_at).toLocaleDateString()}
-      </div>
+      <div className="mb-4 text-sm text-gray-500">작성일: {new Date(notice.created_at).toLocaleDateString()}</div>
       <div className="whitespace-pre-wrap">{notice.content}</div>
     </div>
   );

--- a/src/app/notice/_components/NoticeBoard.tsx
+++ b/src/app/notice/_components/NoticeBoard.tsx
@@ -6,7 +6,7 @@ export default async function NoticeBoard() {
   const notices: NoticeTable[] = await getNotices();
 
   return (
-    <div className="my-2 space-y-4 border border-primary">
+    <div className="my-2 flex flex-col border border-primary">
       {notices.map((notice) => (
         <NoticeItem key={notice.id} notice={notice} />
       ))}

--- a/src/app/notice/_components/NoticeBoard.tsx
+++ b/src/app/notice/_components/NoticeBoard.tsx
@@ -1,9 +1,9 @@
 import { getNotices } from '../_lib/noticeService';
-import { NoticeContent } from '@/lib/types/notice';
+import { NoticeTable } from '@/lib/types/database';
 import NoticeItem from './NoticeItem';
 
 export default async function NoticeBoard() {
-  const notices: NoticeContent[] = await getNotices();
+  const notices: NoticeTable[] = await getNotices();
 
   return (
     <div className="my-2 space-y-4 border border-primary">

--- a/src/app/notice/_components/NoticeBoard.tsx
+++ b/src/app/notice/_components/NoticeBoard.tsx
@@ -1,4 +1,4 @@
-import { getNotices } from '@/lib/noticeService';
+import { getNotices } from '../_lib/noticeService';
 import { NoticeContent } from '@/lib/types/notice';
 import NoticeItem from './NoticeItem';
 
@@ -6,7 +6,7 @@ export default async function NoticeBoard() {
   const notices: NoticeContent[] = await getNotices();
 
   return (
-    <div className="space-y-4">
+    <div className="my-2 space-y-4 border border-primary">
       {notices.map((notice) => (
         <NoticeItem key={notice.id} notice={notice} />
       ))}

--- a/src/app/notice/_components/NoticeItem.tsx
+++ b/src/app/notice/_components/NoticeItem.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import { NoticeContent } from '@/lib/types/notice';
+import { NoticeTable } from '@/lib/types/database';
 import Link from 'next/link';
 
 interface NoticeItemProps {
-  notice: NoticeContent;
+  notice: NoticeTable;
 }
 
 export default function NoticeItem({ notice }: NoticeItemProps) {

--- a/src/app/notice/_components/NoticeItem.tsx
+++ b/src/app/notice/_components/NoticeItem.tsx
@@ -10,11 +10,11 @@ interface NoticeItemProps {
 export default function NoticeItem({ notice }: NoticeItemProps) {
   return (
     <Link href={`/notice/${notice.id}`}>
-      <div className="mb-4 cursor-pointer rounded border p-4 active:bg-gray-50">
+      <div className="mb-1 cursor-pointer rounded border p-4 active:bg-gray-50">
         <h2 className="text-base font-semibold">{notice.title}</h2>
-        <p className="line-clamp-2 text-gray-600">{notice.content}</p>
-        <div className="mt-2 text-sm text-gray-500">
-          작성자: {notice.author} | 작성일: {new Date(notice.created_at).toLocaleDateString()}
+        <div className="text-#dedede mt-2 flex flex-row justify-between text-sm">
+          <p>{new Date(notice.created_at).toLocaleDateString()}</p>
+          <p>{notice.author}</p>
         </div>
       </div>
     </Link>

--- a/src/app/notice/_components/NoticeItem.tsx
+++ b/src/app/notice/_components/NoticeItem.tsx
@@ -10,8 +10,8 @@ interface NoticeItemProps {
 export default function NoticeItem({ notice }: NoticeItemProps) {
   return (
     <Link href={`/notice/${notice.id}`}>
-      <div className="mb-4 cursor-pointer rounded border p-4 hover:bg-gray-50">
-        <h2 className="text-xl font-semibold">{notice.title}</h2>
+      <div className="mb-4 cursor-pointer rounded border p-4 active:bg-gray-50">
+        <h2 className="text-base font-semibold">{notice.title}</h2>
         <p className="line-clamp-2 text-gray-600">{notice.content}</p>
         <div className="mt-2 text-sm text-gray-500">
           작성자: {notice.author} | 작성일: {new Date(notice.created_at).toLocaleDateString()}

--- a/src/app/notice/_lib/noticeService.ts
+++ b/src/app/notice/_lib/noticeService.ts
@@ -1,4 +1,4 @@
-import { createServerSupabaseClient } from './supabase-server';
+import { createServerSupabaseClient } from '@/lib/supabase-server';
 import { NoticeContent } from '@/lib/types/notice';
 
 export async function getNotices(): Promise<NoticeContent[]> {

--- a/src/app/notice/_lib/noticeService.ts
+++ b/src/app/notice/_lib/noticeService.ts
@@ -1,26 +1,19 @@
-import { createServerSupabaseClient } from '@/lib/supabase-server';
-import { NoticeContent } from '@/lib/types/notice';
+// app/notice/_lib/noticeService.ts
 
-export async function getNotices(): Promise<NoticeContent[]> {
-  const supabase = createServerSupabaseClient();
-  const { data, error } = await supabase.from('notices').select('*').order('created_at', { ascending: false });
+import { fetchAllFromTable, fetchOneFromTable, fetchRecentPostTitles } from '@/lib/supabase-helpers';
+import { NoticeTable } from '@/lib/types/database';
 
-  if (error) {
-    console.error('Error fetching notices:', error);
-    return [];
-  }
-
-  return data || [];
+// 모든 공지사항을 가져오는 함수
+export async function getNotices(): Promise<NoticeTable[]> {
+  return fetchAllFromTable('notices');
 }
 
-export async function getNoticeById(id: number): Promise<NoticeContent | null> {
-  const supabase = createServerSupabaseClient();
-  const { data, error } = await supabase.from('notices').select('*').eq('id', id).single();
+// 특정 ID의 공지사항을 가져오는 함수
+export async function getNoticeById(id: number): Promise<NoticeTable | null> {
+  return fetchOneFromTable('notices', id);
+}
 
-  if (error) {
-    console.error('Error fetching notice:', error);
-    return null;
-  }
-
-  return data;
+// 최근 공지사항의 제목, ID, 생성일을 가져오는 함수
+export async function getRecentNotices(limit: number = 5): Promise<Pick<NoticeTable, 'id' | 'title' | 'created_at'>[]> {
+  return fetchRecentPostTitles('notices', limit);
 }

--- a/src/lib/supabase-helpers.ts
+++ b/src/lib/supabase-helpers.ts
@@ -1,0 +1,49 @@
+import { createServerSupabaseClient } from '@/lib/supabase-server';
+import { TableName, RecordType } from '@/lib/types/database';
+
+// 테이블에서 모든 데이터를 가져오는 범용 함수
+export async function fetchAllFromTable<T extends TableName>(
+  tableName: T,
+  columns: string = '*',
+): Promise<RecordType<T>[]> {
+  const supabase = createServerSupabaseClient();
+  const { data, error } = await supabase.from(tableName).select(columns).order('created_at', { ascending: false });
+
+  if (error) {
+    console.error(`${tableName}에서 데이터를 가져오는 중 오류 발생:`, error);
+    return [];
+  }
+  // 타입 안전성을 위해 unknown으로 먼저 변환한 후 RecordType<T>[]로 변환
+  return data as unknown as RecordType<T>[];
+}
+
+// 테이블에서 특정 ID의 단일 레코드를 가져오는 범용 함수
+export async function fetchOneFromTable<T extends TableName>(tableName: T, id: number): Promise<RecordType<T> | null> {
+  const supabase = createServerSupabaseClient();
+  const { data, error } = await supabase.from(tableName).select('*').eq('id', id).single();
+
+  if (error) {
+    console.error(`${tableName}에서 ID ${id}의 레코드를 가져오는 중 오류 발생:`, error);
+    return null;
+  }
+  return data as RecordType<T>;
+}
+
+// 메인 페이지용: 특정 테이블의 최근 게시물 제목 몇 개를 가져오는 범용 함수
+export async function fetchRecentPostTitles<T extends TableName>(
+  tableName: T,
+  limit: number = 5,
+): Promise<Pick<RecordType<T>, 'id' | 'title' | 'created_at'>[]> {
+  const supabase = createServerSupabaseClient();
+  const { data, error } = await supabase
+    .from(tableName)
+    .select('id, title, created_at')
+    .order('created_at', { ascending: false })
+    .limit(limit);
+
+  if (error) {
+    console.error(`${tableName}에서 최근 게시물을 가져오는 중 오류 발생:`, error);
+    return [];
+  }
+  return data as Pick<RecordType<T>, 'id' | 'title' | 'created_at'>[];
+}

--- a/src/lib/supabase-helpers.ts
+++ b/src/lib/supabase-helpers.ts
@@ -1,7 +1,7 @@
 import { createServerSupabaseClient } from '@/lib/supabase-server';
 import { TableName, RecordType } from '@/lib/types/database';
 
-// 테이블에서 모든 데이터를 가져오는 범용 함수
+// 테이블에서 모든 데이터를 가져오는 범용 함수 (해당 페이지들에서 사용)
 export async function fetchAllFromTable<T extends TableName>(
   tableName: T,
   columns: string = '*',

--- a/src/lib/types/database.ts
+++ b/src/lib/types/database.ts
@@ -1,0 +1,29 @@
+/* 기본 타입 */
+export interface BaseRecord {
+  id: number;
+  created_at: string;
+}
+
+/* 공지사항 게시글 타입 */
+export interface NoticeTable extends BaseRecord {
+  title: string;
+  content: string;
+  author: string;
+}
+
+/* Forum 게시글 타입 */
+export interface ForumPostTable extends BaseRecord {
+  title: string;
+  content: string;
+  author: string;
+}
+
+/* 테이블 이름 정의 */
+export type TableName = 'notices' | 'forum_posts';
+
+/* 테이블별 레코드 타입 */
+export type RecordType<T extends TableName> = T extends 'notices'
+  ? NoticeTable
+  : T extends 'forum_posts'
+    ? ForumPostTable
+    : never;

--- a/src/lib/types/notice.ts
+++ b/src/lib/types/notice.ts
@@ -1,8 +1,0 @@
-/* Supabase Notice Table Types */
-export interface NoticeContent {
-  id: number;
-  created_at: string;
-  title: string;
-  content: string;
-  author: string;
-}


### PR DESCRIPTION
## 기능 내용

<img width="1059" alt="image" src="https://github.com/user-attachments/assets/9482e5e1-a680-434a-889c-83e534e1705d">

## 작업 내용

### Supabase
1. 테이블 전체 내용을 가져오는 함수 개발 (페이지용)
2. 테이블의 특정 ID의 단일 레코드를 가져오는 함수 개발 (페이지 -> 상세페이지로 넘어갈 때 사용)
3. 메인페이지에서 preview개념으로 사용할 특정 테이블의 최근 게시글 제목, 작성일자를 가져오는 함수 개발

## 이슈 트래커

ref:
resolved:
