### PR TITLE
[✨Feat] 공지사항 카테고리를 클릭했을 때 해당하는 게시글 렌더링되도록 개발

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,7 +1,8 @@
+@import url('https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable-dynamic-subset.min.css');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-@import url('https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable-dynamic-subset.min.css');
 
 /* 나눔 스퀘어 네오 폰트 페이스 */
 @font-face {

--- a/src/app/notice/_components/NoticeBoard.tsx
+++ b/src/app/notice/_components/NoticeBoard.tsx
@@ -1,15 +1,67 @@
-import { getNotices } from '../_lib/noticeService';
+'use client';
+
 import { NoticeTable } from '@/lib/types/database';
+import { useCategoryStore } from '@/lib/stores/categoryStore';
+import { getFilteredNotices } from '@/app/notice/_lib/noticeService';
+import { useEffect, useState } from 'react';
 import NoticeItem from './NoticeItem';
 
-export default async function NoticeBoard() {
-  const notices: NoticeTable[] = await getNotices();
+// 공지사항 게시판 컴포넌트의 props 타입 정의
+interface NoticeBoardProps {
+  initialNotices: NoticeTable[];
+}
 
+export default function NoticeBoard({ initialNotices }: NoticeBoardProps) {
+  // 상태 관리: 공지사항 목록, 로딩 상태, 에러 메시지
+  const [notices, setNotices] = useState<NoticeTable[]>(initialNotices);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // 카테고리 스토어에서 선택된 카테고리 가져오기
+  const { selectedCategory } = useCategoryStore();
+
+  // 선택된 카테고리가 변경될 때마다 공지사항 필터링
+  useEffect(() => {
+    async function fetchFilteredNotices() {
+      setIsLoading(true);
+      setError(null);
+      try {
+        if (selectedCategory === '전체') {
+          // '전체' 카테고리 선택 시 초기 공지사항 표시
+          setNotices(initialNotices);
+        } else {
+          // 선택된 카테고리에 따라 공지사항 필터링
+          const filteredNotices = await getFilteredNotices(selectedCategory);
+          setNotices(filteredNotices);
+        }
+      } catch (error) {
+        console.error('공지사항을 가져오는 중 오류 발생:', error);
+        setError('공지사항을 불러오는 데 실패했습니다. 잠시 후 다시 시도해 주세요.');
+      } finally {
+        setIsLoading(false);
+      }
+    }
+    fetchFilteredNotices();
+  }, [selectedCategory, initialNotices]);
+
+  // 로딩 중일 때 표시할 내용
+  if (isLoading) {
+    return <div>카테고리 변경 중...</div>;
+  }
+
+  // 에러 발생 시 표시할 내용
+  if (error) {
+    return <div className="text-red-500">{error}</div>;
+  }
+
+  // 공지사항 목록 렌더링
   return (
     <div className="my-5 flex flex-col">
-      {notices.map((notice) => (
-        <NoticeItem key={notice.id} notice={notice} />
-      ))}
+      {notices.length > 0 ? (
+        notices.map((notice) => <NoticeItem key={notice.id} notice={notice} />)
+      ) : (
+        <div>이 카테고리에 해당하는 공지사항이 없습니다.</div>
+      )}
     </div>
   );
 }

--- a/src/app/notice/_components/NoticeBoard.tsx
+++ b/src/app/notice/_components/NoticeBoard.tsx
@@ -6,7 +6,7 @@ export default async function NoticeBoard() {
   const notices: NoticeTable[] = await getNotices();
 
   return (
-    <div className="my-2 flex flex-col border border-primary">
+    <div className="my-5 flex flex-col">
       {notices.map((notice) => (
         <NoticeItem key={notice.id} notice={notice} />
       ))}

--- a/src/app/notice/_components/NoticeItem.tsx
+++ b/src/app/notice/_components/NoticeItem.tsx
@@ -11,7 +11,7 @@ export default function NoticeItem({ notice }: NoticeItemProps) {
   return (
     <Link href={`/notice/${notice.id}`}>
       <div className="cursor-pointer border-t border-primary p-2 active:bg-gray-50">
-        <h2 className="text-14 font-semibold">{notice.title}</h2>
+        <p className="text-14 font-semibold">{notice.title}</p>
         <div className="mt-1 flex flex-row justify-between text-12 text-gray-500">
           <p>{new Date(notice.created_at).toLocaleDateString()}</p>
           <p>{notice.author}</p>

--- a/src/app/notice/_components/NoticeItem.tsx
+++ b/src/app/notice/_components/NoticeItem.tsx
@@ -10,9 +10,9 @@ interface NoticeItemProps {
 export default function NoticeItem({ notice }: NoticeItemProps) {
   return (
     <Link href={`/notice/${notice.id}`}>
-      <div className="mb-1 cursor-pointer rounded border p-4 active:bg-gray-50">
-        <h2 className="text-base font-semibold">{notice.title}</h2>
-        <div className="text-#dedede mt-2 flex flex-row justify-between text-sm">
+      <div className="cursor-pointer border-t border-primary p-2 active:bg-gray-50">
+        <h2 className="text-14 font-semibold">{notice.title}</h2>
+        <div className="mt-1 flex flex-row justify-between text-12 text-gray-500">
           <p>{new Date(notice.created_at).toLocaleDateString()}</p>
           <p>{notice.author}</p>
         </div>

--- a/src/app/notice/_lib/noticeService.ts
+++ b/src/app/notice/_lib/noticeService.ts
@@ -1,19 +1,24 @@
-// app/notice/_lib/noticeService.ts
-
 import { fetchAllFromTable, fetchOneFromTable, fetchRecentPostTitles } from '@/lib/supabase-helpers';
+import { fetchFilteredFromTable } from '@/lib/supabase-helpers-client';
 import { NoticeTable } from '@/lib/types/database';
 
-// 모든 공지사항을 가져오는 함수
+// 모든 공지사항을 가져오는 함수 (ServerComponent)
 export async function getNotices(): Promise<NoticeTable[]> {
   return fetchAllFromTable('notices');
 }
 
-// 특정 ID의 공지사항을 가져오는 함수
+// 특정 ID의 공지사항을 가져오는 함수 (ServerComponent)
 export async function getNoticeById(id: number): Promise<NoticeTable | null> {
   return fetchOneFromTable('notices', id);
 }
 
-// 최근 공지사항의 제목, ID, 생성일을 가져오는 함수
+// 최근 공지사항의 제목, ID, 생성일을 가져오는 함수 (ServerComponent)
 export async function getRecentNotices(limit: number = 5): Promise<Pick<NoticeTable, 'id' | 'title' | 'created_at'>[]> {
   return fetchRecentPostTitles('notices', limit);
+}
+
+// 해당 카테고리에 속하는 공지사항을 가져오는 함수 (ClientComponent)
+export async function getFilteredNotices(category: string): Promise<NoticeTable[]> {
+  const notices = await fetchFilteredFromTable('notices', category);
+  return notices;
 }

--- a/src/app/notice/page.tsx
+++ b/src/app/notice/page.tsx
@@ -1,13 +1,16 @@
 import Title from '@/components/Title';
 import SlideCategory from '@/components/SlideCategory';
 import NoticeBoard from './_components/NoticeBoard';
+import { getNotices } from './_lib/noticeService';
 
 export default async function NoticesPage() {
+  const initialNotices = await getNotices();
+
   return (
-    <section className="">
+    <section>
       <Title title="Notice" href="/board" isMainPage={false} />
       <SlideCategory boardType="notice" />
-      <NoticeBoard />
+      <NoticeBoard initialNotices={initialNotices} />
     </section>
   );
 }

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -9,9 +9,19 @@ export default function Footer() {
           <p className="font-semibold">Magok, GreenFriends</p>
         </div>
         <div className="mb-4 md:mb-0">
-          <p className="font-semibold">Developer</p>
-          <p>Email. fridaynight@kakao.com</p>
-          <p>GitHub. github.com/kimzeze</p>
+          <p className="font-semibold">Developers</p>
+          <div className="flex flex-row">
+            <div>
+              <p className="font-semibold">Kim Dohyeon</p>
+              <p>Email. fridaynight@kakao.com</p>
+              <p>GitHub. github.com/kimzeze</p>
+            </div>
+            <div className="ml-4">
+              <p className="font-semibold">Hyeon Jisoo</p>
+              <p>Email. hyunzsu@kakao.com</p>
+              <p>GitHub. github.com/hyunzsu</p>
+            </div>
+          </div>
         </div>
         <div className="mb-4 md:mb-0">
           <p>본 사이트는 녹색친구들 [마곡] 입주예정자가 운영하는 사이트임을 알립니다.</p>
@@ -19,7 +29,7 @@ export default function Footer() {
         </div>
         <div>
           <p className="font-semibold">
-            Copyright © 2024 Kimdohyeon. <br /> All rights reserved.
+            Copyright © 2024 Kimdohyeon. Hyenjisoo. <br /> All rights reserved.
           </p>
         </div>
       </div>

--- a/src/lib/supabase-helpers-client.ts
+++ b/src/lib/supabase-helpers-client.ts
@@ -1,0 +1,83 @@
+import { supabase } from './supabase';
+import { TableName, RecordType } from '@/lib/types/database';
+
+// 데이터베이스 연결을 확인하는 함수
+async function checkDatabaseConnection() {
+  try {
+    const { data, error } = await supabase.from('notices').select('count', { count: 'exact' });
+    if (error) throw error;
+    console.log('데이터베이스 연결 성공. 행 수:', data);
+  } catch (error) {
+    console.error('데이터베이스 연결 실패:', error);
+    throw error;
+  }
+}
+
+// 클라이언트에서 특정 테이블의 모든 데이터를 가져오는 함수
+export async function fetchAllFromTableClient<T extends TableName>(
+  tableName: T,
+  columns: string = '*',
+): Promise<RecordType<T>[]> {
+  const { data, error } = await supabase.from(tableName).select(columns).order('created_at', { ascending: false });
+
+  if (error) {
+    console.error(`클라이언트: ${tableName}에서 데이터를 가져오는 중 오류 발생:`, error);
+    return [];
+  }
+  return data as unknown as RecordType<T>[];
+}
+
+// 클라이언트에서 특정 테이블의 단일 레코드를 ID로 가져오는 함수
+export async function fetchOneFromTableClient<T extends TableName>(
+  tableName: T,
+  id: number,
+): Promise<RecordType<T> | null> {
+  const { data, error } = await supabase.from(tableName).select('*').eq('id', id).single();
+
+  if (error) {
+    console.error(`클라이언트: ${tableName}에서 ID ${id}의 레코드를 가져오는 중 오류 발생:`, error);
+    return null;
+  }
+  // 타입 단언을 사용하여 타입 에러 해결 (추후 수정 필요)
+  return data as RecordType<T>;
+}
+
+// 특정 테이블에서 카테고리별로 필터링된 데이터를 가져오는 함수
+export async function fetchFilteredFromTable<T extends TableName>(
+  tableName: T,
+  category: string,
+  columns: string = '*',
+): Promise<RecordType<T>[]> {
+  console.log('테이블에서 가져오는 중: ', tableName, '카테고리:', category);
+  await checkDatabaseConnection();
+
+  // 1. 먼저 전체 데이터를 가져와 로그로 출력
+  const { data: allData, error: allDataError } = await supabase.from(tableName).select(columns);
+
+  console.log('테이블의 모든 데이터:', allData);
+
+  if (allDataError) {
+    console.error('모든 데이터 가져오기 오류:', allDataError);
+    throw allDataError;
+  }
+
+  // 2. 카테고리 필터링을 적용
+  let query = supabase.from(tableName).select(columns);
+
+  if (category !== '전체') {
+    // 대소문자를 구분하지 않는 검색을 위해 ilike 사용
+    query = query.ilike('category', `%${category}%`);
+  }
+
+  const { data, error } = await query;
+
+  if (error) {
+    console.error(`${tableName}에서 데이터 가져오기 오류:`, error);
+    throw error;
+  }
+
+  console.log('필터링된 데이터:', data);
+
+  // 타입 단언을 사용하여 타입 에러 해결 (추후 수정 필요)
+  return data as unknown as RecordType<T>[];
+}

--- a/src/lib/supabase-helpers-client.ts
+++ b/src/lib/supabase-helpers-client.ts
@@ -51,19 +51,10 @@ export async function fetchFilteredFromTable<T extends TableName>(
   console.log('테이블에서 가져오는 중: ', tableName, '카테고리:', category);
   await checkDatabaseConnection();
 
-  // 1. 먼저 전체 데이터를 가져와 로그로 출력
-  const { data: allData, error: allDataError } = await supabase.from(tableName).select(columns);
-
-  console.log('테이블의 모든 데이터:', allData);
-
-  if (allDataError) {
-    console.error('모든 데이터 가져오기 오류:', allDataError);
-    throw allDataError;
-  }
-
-  // 2. 카테고리 필터링을 적용
+  // 카테고리 필터링 적용
   let query = supabase.from(tableName).select(columns);
 
+  // 카테고리가 전체가 아닐경우 카테고리 필터링 적용
   if (category !== '전체') {
     // 대소문자를 구분하지 않는 검색을 위해 ilike 사용
     query = query.ilike('category', `%${category}%`);

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -3,4 +3,8 @@ import { createClient } from '@supabase/supabase-js';
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
 const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
 
+if (!supabaseUrl || !supabaseAnonKey) {
+  throw new Error('Missing Supabase environment variables');
+}
+
 export const supabase = createClient(supabaseUrl, supabaseAnonKey);

--- a/src/lib/types/database.ts
+++ b/src/lib/types/database.ts
@@ -4,11 +4,15 @@ export interface BaseRecord {
   created_at: string;
 }
 
+/* 공지사항 태그 타입 */
+export type NoticeTag = '알림' | '입주' | 'Event' | '기타' | '전체';
+
 /* 공지사항 게시글 타입 */
 export interface NoticeTable extends BaseRecord {
   title: string;
   content: string;
   author: string;
+  tag: NoticeTag;
 }
 
 /* Forum 게시글 타입 */


### PR DESCRIPTION
## 기능 내용

![0813](https://github.com/user-attachments/assets/433f068a-6deb-4d85-805e-6b0763b7175c)

- Supabase에서 notices 테이블에 접근하여 해당 카테고리에 맞는 게시글만 렌더링되도록 추가하였습니다.

## 작업 내용

### 1. 클라이언트 컴포넌트에서 Supabase 테이블 데이터를 불러오는 공용 함수 생성

<img width="783" alt="image" src="https://github.com/user-attachments/assets/6d8abb77-754e-43b9-bef6-01a82f9f2fd3">

### 2. NoticeBoard를 클라이언트 컴포넌트로변경
<img width="515" alt="image" src="https://github.com/user-attachments/assets/804900a0-2912-4ce7-8559-534a64e6f9fa">

### 3. Zustand로 선택된 카테고리를 저장하고 카테고리가 변경될 때마다 해당 카테고리의 게시글 요청
### 4. 전체 카테고리일 때는 notice/page.tsx에서 요청한 초기데이터 넣도록 개발

## 이슈 트래커

ref:
resolved:
