### PR TITLE
[✨feat] 공지사항 상세페이지에 이미지 불러오기 추가

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,7 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   images: {
-    domains: ['localhost', '*'],
+    domains: ['localhost', '*', 'vsybjuqprbvflfddzcnp.supabase.co'],
   },
 };
 

--- a/src/app/notice/[id]/page.tsx
+++ b/src/app/notice/[id]/page.tsx
@@ -2,6 +2,7 @@ import { BackButtonServer } from '@/components/_index';
 import { getNoticeById } from '../_lib/noticeService';
 import { NoticeTable } from '@/lib/types/database';
 import ReactMarkdown from 'react-markdown';
+import Image from 'next/image';
 
 export const revalidate = 60; // 60초마다 재검증
 
@@ -18,6 +19,7 @@ export default async function NoticeDetailPage({ params }: { params: { id: strin
       <div className="pt-1 text-sm font-semibold text-secondary">{notice.category}</div>
       <h1 className="mb-4 border-b border-primary pb-2 text-xl font-bold">{notice.title}</h1>
       <div className="whitespace-pre-wrap py-2 text-14">
+        {notice.image && <Image src={notice.image} alt="공지사항 이미지" width={350} height={185} className="mb-4" />}
         <ReactMarkdown>{notice.content}</ReactMarkdown>
       </div>
       <div className="mb-2 flex justify-end border-b border-primary py-1 text-sm text-gray-500">

--- a/src/lib/types/database.ts
+++ b/src/lib/types/database.ts
@@ -13,6 +13,7 @@ export interface NoticeTable extends BaseRecord {
   content: string;
   author: string;
   category: NoticeTag;
+  image?: string;
 }
 
 /* Forum 게시글 타입 */


### PR DESCRIPTION
## 기능 내용

<img width="612" alt="image" src="https://github.com/user-attachments/assets/72eddbd3-e22c-42a5-87ac-d49165fd9e76">

## 작업 내용

### Supabase Storage

- Supabase Storage에 이미지 버킷을 만들고 업로드하여 URL을 가져왔습니다.
- 지금은 테이블에 직접 버킷의 이미지 URL을 넣어주고 있습니다. 추후 수정해야할 기능입니다.


## 이슈 트래커

ref:
resolved:
